### PR TITLE
Normalize user text input

### DIFF
--- a/src/slack_annotations/format.py
+++ b/src/slack_annotations/format.py
@@ -7,7 +7,7 @@ NONE_TEXT = "(None)"
 
 
 def normalize_title(text: str) -> str:
-    text = html.escape(text, quote=False)
+    text = html.escape(text)
     return " ".join(text.split())
 
 
@@ -72,10 +72,8 @@ def format_annotations(annotations: list[dict[str, Any]]) -> str:
 
 
 def _build_annotation_summary(annotation: dict[str, Any]) -> str:
-    username = html.escape(annotation["user"].split(":")[1].split("@")[0], quote=False)
-    display_name = html.escape(
-        annotation["user_info"]["display_name"] or "", quote=False
-    )
+    username = html.escape(annotation["user"].split(":")[1].split("@")[0])
+    display_name = html.escape(annotation["user_info"]["display_name"] or "")
     uri = annotation["uri"]
 
     try:

--- a/src/slack_annotations/format.py
+++ b/src/slack_annotations/format.py
@@ -40,7 +40,7 @@ def _get_text(annotation: dict[str, Any]) -> str:
     text = annotation.get("text", None)
     if not text:
         text = NONE_TEXT
-    return html.escape(_trim_text(text))
+    return _trim_text(html.escape(text))
 
 
 def format_annotations(annotations: list[dict[str, Any]]) -> str:

--- a/src/slack_annotations/format.py
+++ b/src/slack_annotations/format.py
@@ -6,7 +6,7 @@ MAX_TEXT_LENGTH = 2000
 NONE_TEXT = "(None)"
 
 
-def sanitize_title(text: str) -> str:
+def normalize_title(text: str) -> str:
     text = html.escape(text)
     return " ".join(text.split())
 
@@ -40,7 +40,7 @@ def _get_text(annotation: dict[str, Any]) -> str:
     text = annotation.get("text", None)
     if not text:
         text = NONE_TEXT
-    return _trim_text(text)
+    return html.escape(_trim_text(text))
 
 
 def format_annotations(annotations: list[dict[str, Any]]) -> str:
@@ -72,16 +72,16 @@ def format_annotations(annotations: list[dict[str, Any]]) -> str:
 
 
 def _build_annotation_summary(annotation: dict[str, Any]) -> str:
-    username = annotation["user"].split(":")[1].split("@")[0]
-    display_name = annotation["user_info"]["display_name"]
+    username = html.escape(annotation["user"].split(":")[1].split("@")[0])
+    display_name = html.escape(annotation["user_info"]["display_name"] or "")
     uri = annotation["uri"]
 
     try:
-        title = annotation["document"]["title"][0]
+        title = normalize_title(annotation["document"]["title"][0])
     except Exception:  # pylint:disable=broad-exception-caught
         title = None
     if title:
-        document_link = f"<{uri}|{sanitize_title(title)}>"
+        document_link = f"<{uri}|{title}>"
     else:
         document_link = uri
 

--- a/src/slack_annotations/format.py
+++ b/src/slack_annotations/format.py
@@ -1,8 +1,14 @@
 import json
+import html
 from typing import Any
 
 MAX_TEXT_LENGTH = 2000
 NONE_TEXT = "(None)"
+
+
+def sanitize_title(text: str) -> str:
+    text = html.escape(text)
+    return " ".join(text.split())
 
 
 def _format_annotation(annotation: dict[str, Any]) -> dict[str, Any]:
@@ -75,7 +81,7 @@ def _build_annotation_summary(annotation: dict[str, Any]) -> str:
     except Exception:  # pylint:disable=broad-exception-caught
         title = None
     if title:
-        document_link = f"<{uri}|{title}>"
+        document_link = f"<{uri}|{sanitize_title(title)}>"
     else:
         document_link = uri
 

--- a/src/slack_annotations/format.py
+++ b/src/slack_annotations/format.py
@@ -7,7 +7,7 @@ NONE_TEXT = "(None)"
 
 
 def normalize_title(text: str) -> str:
-    text = html.escape(text)
+    text = html.escape(text, quote=False)
     return " ".join(text.split())
 
 
@@ -40,7 +40,7 @@ def _get_text(annotation: dict[str, Any]) -> str:
     text = annotation.get("text", None)
     if not text:
         text = NONE_TEXT
-    return _trim_text(html.escape(text))
+    return _trim_text(html.escape(text, quote=False))
 
 
 def format_annotations(annotations: list[dict[str, Any]]) -> str:
@@ -72,8 +72,10 @@ def format_annotations(annotations: list[dict[str, Any]]) -> str:
 
 
 def _build_annotation_summary(annotation: dict[str, Any]) -> str:
-    username = html.escape(annotation["user"].split(":")[1].split("@")[0])
-    display_name = html.escape(annotation["user_info"]["display_name"] or "")
+    username = html.escape(annotation["user"].split(":")[1].split("@")[0], quote=False)
+    display_name = html.escape(
+        annotation["user_info"]["display_name"] or "", quote=False
+    )
     uri = annotation["uri"]
 
     try:

--- a/src/slack_annotations/format.py
+++ b/src/slack_annotations/format.py
@@ -37,7 +37,7 @@ def _trim_text(text: str) -> str:
 
 
 def _get_text(annotation: dict[str, Any]) -> str:
-    text = annotation.get("text", None)
+    text = annotation.get("text")
     if not text:
         text = NONE_TEXT
     return _trim_text(text)

--- a/src/slack_annotations/format.py
+++ b/src/slack_annotations/format.py
@@ -40,7 +40,7 @@ def _get_text(annotation: dict[str, Any]) -> str:
     text = annotation.get("text", None)
     if not text:
         text = NONE_TEXT
-    return _trim_text(html.escape(text, quote=False))
+    return _trim_text(text)
 
 
 def format_annotations(annotations: list[dict[str, Any]]) -> str:

--- a/src/slack_annotations/format.py
+++ b/src/slack_annotations/format.py
@@ -1,5 +1,5 @@
-import json
 import html
+import json
 from typing import Any
 
 MAX_TEXT_LENGTH = 2000

--- a/tests/unit/slack_annotations/format_test.py
+++ b/tests/unit/slack_annotations/format_test.py
@@ -6,7 +6,7 @@ from slack_annotations.format import (
     _get_quote,
     _trim_text,
     format_annotations,
-    sanitize_title,
+    normalize_title,
 )
 
 
@@ -32,10 +32,10 @@ class TestGetQuote:
 
 class TestSanitizeTitle:
     def test_newline(self):
-        assert sanitize_title("sign \n up") == "sign up"
+        assert normalize_title("sign \n up") == "sign up"
 
     def test_angle_bracket(self):
-        assert sanitize_title("sign < up") == "sign &lt; up"
+        assert normalize_title("sign < up") == "sign &lt; up"
 
 
 def test_trim_long_text():

--- a/tests/unit/slack_annotations/format_test.py
+++ b/tests/unit/slack_annotations/format_test.py
@@ -6,6 +6,7 @@ from slack_annotations.format import (
     _get_quote,
     _trim_text,
     format_annotations,
+    sanitize_title,
 )
 
 
@@ -27,6 +28,14 @@ class TestGetQuote:
         annotation = {"target": [{"selector": [{}, {"exact": exact}]}]}
 
         assert _get_quote(annotation) == exact
+
+
+class TestSanitizeTitle:
+    def test_newline(self):
+        assert sanitize_title("sign \n up") == "sign up"
+
+    def test_angle_bracket(self):
+        assert sanitize_title("sign < up") == "sign &lt; up"
 
 
 def test_trim_long_text():
@@ -139,6 +148,30 @@ class TestFormatAnnotation:
                 {
                     "type": "mrkdwn",
                     "text": "*Reply* (<https://hyp.is/test_annotation_id_1/example.com/|in-context link>):",
+                },
+                {"type": "plain_text", "text": "(None)"},
+            ],
+        }
+
+    def test_newline(self):
+        annotation = {
+            "user": "acct:test_user_1@hypothes.is",
+            "uri": "https://example.com/",
+            "links": {"incontext": "https://hyp.is/test_annotation_id_1/example.com/"},
+            "document": {"title": ["Annotation \n title"]},
+            "user_info": {"display_name": None},
+        }
+
+        assert _format_annotation(annotation) == {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "`test_user_1` annotated <https://example.com/|Annotation title>:",
+            },
+            "fields": [
+                {
+                    "type": "mrkdwn",
+                    "text": "*Page Note* (<https://hyp.is/test_annotation_id_1/example.com/|in-context link>):",
                 },
                 {"type": "plain_text", "text": "(None)"},
             ],

--- a/tests/unit/slack_annotations/format_test.py
+++ b/tests/unit/slack_annotations/format_test.py
@@ -30,12 +30,15 @@ class TestGetQuote:
         assert _get_quote(annotation) == exact
 
 
-class TestSanitizeTitle:
+class TestNormalizeTitle:
     def test_newline(self):
         assert normalize_title("sign \n up") == "sign up"
 
     def test_angle_bracket(self):
         assert normalize_title("sign < up") == "sign &lt; up"
+
+    def test_quote(self):
+        assert normalize_title('sign " up') == 'sign " up'
 
 
 def test_trim_long_text():

--- a/tests/unit/slack_annotations/format_test.py
+++ b/tests/unit/slack_annotations/format_test.py
@@ -38,7 +38,7 @@ class TestNormalizeTitle:
         assert normalize_title("sign < up") == "sign &lt; up"
 
     def test_quote(self):
-        assert normalize_title('sign " up') == 'sign " up'
+        assert normalize_title('sign " up') == "sign &quot; up"
 
 
 def test_trim_long_text():


### PR DESCRIPTION
Fixes [this](https://hypothes-is.slack.com/archives/C03DXR1BA3B/p1734102301709489?thread_ts=1734101713.589499&cid=C03DXR1BA3B)

Context is slack using their own version of markdown markup.
We need to normalize titles so that [slack links](https://api.slack.com/reference/surfaces/formatting#linking-urls) do not break.
And more generally on top of that we need to [escape user text](https://api.slack.com/reference/surfaces/formatting#escaping) which we render in markdown.