### PR TITLE
Add slack reading workflow

### DIFF
--- a/.github/workflows/eng_annotations.yml
+++ b/.github/workflows/eng_annotations.yml
@@ -11,6 +11,7 @@ jobs:
     with:
       cache_key: eng_annotations
       slack_channel_id: ${{ vars.ENG_ANNOTATIONS_SLACK_CHANNEL_ID }}
+      group_name: ${{ vars.ENG_ANNOTATIONS_GROUP_NAME }}
     secrets:
       SEARCH_PARAMS: ${{ secrets.ENG_ANNOTATIONS_SEARCH_PARAMS }}
       HYPOTHESIS_API_TOKEN: ${{ secrets.HYPOTHESIS_API_TOKEN }}

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -8,6 +8,9 @@ on:
       slack_channel_id:
         required: true
         type: string
+      group_name:
+        required: false
+        type: string
     secrets:
       SEARCH_PARAMS:
         required: false
@@ -43,7 +46,8 @@ jobs:
             slack-annotations \
               --search-params '${{ secrets.SEARCH_PARAMS }}' \
               --token '${{ secrets.HYPOTHESIS_API_TOKEN }}' \
-              --cache-path ~/.cache.json
+              --cache-path ~/.cache.json \
+              --group-name '${{ inputs.GROUP_NAME }}'
             echo EOF
           } >> "$GITHUB_OUTPUT"
       - name: Post to Slack

--- a/.github/workflows/pr_website.yml
+++ b/.github/workflows/pr_website.yml
@@ -19,4 +19,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: curl https://nosnch.in/${{ secrets.PR_WEBSITE_SNITCH_ID }}
-

--- a/.github/workflows/reading.yml
+++ b/.github/workflows/reading.yml
@@ -1,0 +1,22 @@
+name: reading
+concurrency:
+  group: reading
+on:
+  schedule:
+    - cron: '* * * * *'
+  workflow_dispatch:
+jobs:
+  Notify:
+    uses: ./.github/workflows/notify.yml
+    with:
+      cache_key: reading
+      slack_channel_id: ${{ vars.READING_SLACK_CHANNEL_ID }}
+      group_name: ${{ vars.READING_GROUP_NAME }}
+    secrets:
+      SEARCH_PARAMS: ${{ vars.READING_SEARCH_PARAMS }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  Snitch:
+    needs: Notify
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl https://nosnch.in/${{ secrets.READING_SNITCH_ID }}

--- a/src/slack_annotations/cli.py
+++ b/src/slack_annotations/cli.py
@@ -16,6 +16,7 @@ def cli(argv=None):
     parser.add_argument("--search-params")
     parser.add_argument("--token")
     parser.add_argument("--cache-path")
+    parser.add_argument("--group-name")
 
     args = parser.parse_args(argv)
 
@@ -24,4 +25,10 @@ def cli(argv=None):
     else:
         search_params = None
 
-    print(notify(search_params, args.token, args.cache_path))
+    annotations = notify(
+        search_params=search_params,
+        token=args.token,
+        cache_path=args.cache_path,
+        group_name=args.group_name,
+    )
+    print(json.dumps(annotations) if annotations else "")

--- a/src/slack_annotations/core.py
+++ b/src/slack_annotations/core.py
@@ -13,6 +13,7 @@ def notify(
     search_params: dict[str, Any] | None = None,
     token: str | None = None,
     cache_path: str | None = None,
+    group_name: str | None = None,
 ) -> str:
     search_params = _make_search_params(search_params, cache_path)
     headers = _make_headers(token)
@@ -20,7 +21,7 @@ def notify(
     annotations = _fetch_annotations(search_params, headers)
 
     _maybe_update_cache(annotations, cache_path)
-    return format_annotations(annotations)
+    return format_annotations(annotations, group_name)
 
 
 def _make_search_params(

--- a/src/slack_annotations/core.py
+++ b/src/slack_annotations/core.py
@@ -14,7 +14,7 @@ def notify(
     token: str | None = None,
     cache_path: str | None = None,
     group_name: str | None = None,
-) -> str:
+) -> dict[str, Any]:
     search_params = _make_search_params(search_params, cache_path)
     headers = _make_headers(token)
 

--- a/src/slack_annotations/format.py
+++ b/src/slack_annotations/format.py
@@ -11,8 +11,10 @@ def normalize_title(text: str) -> str:
     return " ".join(text.split())
 
 
-def _format_annotation(annotation: dict[str, Any]) -> dict[str, Any]:
-    summary = _build_annotation_summary(annotation)
+def _format_annotation(
+    annotation: dict[str, Any], group_name: str | None = None
+) -> dict[str, Any]:
+    summary = _build_annotation_summary(annotation, group_name)
     fields = _build_annotation_fields(annotation)
     return {
         "type": "section",
@@ -43,7 +45,9 @@ def _get_text(annotation: dict[str, Any]) -> str:
     return _trim_text(text)
 
 
-def format_annotations(annotations: list[dict[str, Any]]) -> str:
+def format_annotations(
+    annotations: list[dict[str, Any]], group_name: str | None = None
+) -> str:
     if not annotations:
         return ""
 
@@ -54,7 +58,7 @@ def format_annotations(annotations: list[dict[str, Any]]) -> str:
     )
     blocks = []
     for annotation in annotations:
-        blocks.append(_format_annotation(annotation))
+        blocks.append(_format_annotation(annotation, group_name))
         blocks.append({"type": "divider"})
     blocks.append(
         {
@@ -71,7 +75,9 @@ def format_annotations(annotations: list[dict[str, Any]]) -> str:
     return json.dumps({"text": summary, "blocks": blocks})
 
 
-def _build_annotation_summary(annotation: dict[str, Any]) -> str:
+def _build_annotation_summary(
+    annotation: dict[str, Any], group_name: str | None = None
+) -> str:
     username = html.escape(annotation["user"].split(":")[1].split("@")[0])
     display_name = html.escape(annotation["user_info"]["display_name"] or "")
     uri = annotation["uri"]
@@ -85,9 +91,11 @@ def _build_annotation_summary(annotation: dict[str, Any]) -> str:
     else:
         document_link = uri
 
-    if display_name:
-        return f"`{username}` ({display_name}) annotated {document_link}:"
-    return f"`{username}` annotated {document_link}:"
+    formatted_user = (
+        f"`{username}` ({display_name})" if display_name else f"`{username}`"
+    )
+    formatted_group = f" in `{group_name}`" if group_name else ""
+    return f"{formatted_user} annotated {document_link}{formatted_group}:"
 
 
 def _build_annotation_fields(annotation: dict[str, Any]) -> list[dict[str, Any]]:

--- a/src/slack_annotations/format.py
+++ b/src/slack_annotations/format.py
@@ -1,5 +1,4 @@
 import html
-import json
 from typing import Any
 
 MAX_TEXT_LENGTH = 2000
@@ -47,9 +46,9 @@ def _get_text(annotation: dict[str, Any]) -> str:
 
 def format_annotations(
     annotations: list[dict[str, Any]], group_name: str | None = None
-) -> str:
+) -> dict[str, Any]:
     if not annotations:
-        return ""
+        return {}
 
     summary = (
         f"{len(annotations)} new annotations"
@@ -72,7 +71,7 @@ def format_annotations(
         }
     )
 
-    return json.dumps({"text": summary, "blocks": blocks})
+    return {"text": summary, "blocks": blocks}
 
 
 def _build_annotation_summary(

--- a/tests/unit/slack_annotations/cli_test.py
+++ b/tests/unit/slack_annotations/cli_test.py
@@ -26,7 +26,9 @@ def test_default(capsys, notify):
 
     cli([])
 
-    notify.assert_called_once_with(None, None, None)
+    notify.assert_called_once_with(
+        search_params=None, token=None, cache_path=None, group_name=None
+    )
     assert capsys.readouterr().out.strip() == notify.return_value
 
 
@@ -36,7 +38,9 @@ def test_search_params(capsys, notify):
     search_params = {"some_key": "some_value"}
     cli(["--search-params", json.dumps(search_params)])
 
-    notify.assert_called_once_with(search_params, None, None)
+    notify.assert_called_once_with(
+        search_params=search_params, token=None, cache_path=None, group_name=None
+    )
     assert capsys.readouterr().out.strip() == notify.return_value
 
 

--- a/tests/unit/slack_annotations/cli_test.py
+++ b/tests/unit/slack_annotations/cli_test.py
@@ -29,7 +29,7 @@ def test_default(capsys, notify):
     notify.assert_called_once_with(
         search_params=None, token=None, cache_path=None, group_name=None
     )
-    assert capsys.readouterr().out.strip() == notify.return_value
+    assert capsys.readouterr().out.strip() == json.dumps(notify.return_value)
 
 
 def test_search_params(capsys, notify):
@@ -41,7 +41,7 @@ def test_search_params(capsys, notify):
     notify.assert_called_once_with(
         search_params=search_params, token=None, cache_path=None, group_name=None
     )
-    assert capsys.readouterr().out.strip() == notify.return_value
+    assert capsys.readouterr().out.strip() == json.dumps(notify.return_value)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/slack_annotations/core_test.py
+++ b/tests/unit/slack_annotations/core_test.py
@@ -46,7 +46,7 @@ class TestNotify:
             content=json.dumps(search_annotations),
         )
 
-        assert notify() == json.dumps(slack_annotations)
+        assert notify() == slack_annotations
 
     @freeze_time("2024-12-01T01:00:00+00:00")
     def test_with_search_after_from_cache_file(
@@ -65,7 +65,7 @@ class TestNotify:
         cache_path = tmp_path / "cache.json"
         cache_path.write_text(json.dumps({"search_after": search_after}))
 
-        assert notify(cache_path=str(cache_path)) == json.dumps(slack_annotations)
+        assert notify(cache_path=str(cache_path)) == slack_annotations
         assert json.loads(cache_path.read_text()) == {
             "search_after": "2024-12-03T18:40:42.325652+00:00"
         }
@@ -85,7 +85,7 @@ class TestNotify:
             match_headers={"Authorization": f"Bearer {token}"},
         )
 
-        assert notify(token=token) == json.dumps(slack_annotations)
+        assert notify(token=token) == slack_annotations
 
 
 @freeze_time("2024-12-01T01:00:00+00:00")

--- a/tests/unit/slack_annotations/format_test.py
+++ b/tests/unit/slack_annotations/format_test.py
@@ -179,3 +179,26 @@ class TestFormatAnnotation:
                 {"type": "plain_text", "text": "(None)"},
             ],
         }
+
+    def test_with_group_name(self):
+        annotation = {
+            "user": "acct:test_user_1@hypothes.is",
+            "uri": "https://example.com/",
+            "links": {"incontext": "https://hyp.is/test_annotation_id_1/example.com/"},
+            "user_info": {"display_name": None},
+        }
+
+        assert _format_annotation(annotation, group_name="Test group") == {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "`test_user_1` annotated https://example.com/ in `Test group`:",
+            },
+            "fields": [
+                {
+                    "type": "mrkdwn",
+                    "text": "*Page Note* (<https://hyp.is/test_annotation_id_1/example.com/|in-context link>):",
+                },
+                {"type": "plain_text", "text": "(None)"},
+            ],
+        }


### PR DESCRIPTION
Adding a `reading` github workflow to post from our "Hypothesis Reading" group to "reading" slack channel just like `eng-annotations` workflow works.  
With a note in annotation summary from which hypothesis group the message is coming from for context.